### PR TITLE
fix: missing prototype in perimeter.h

### DIFF
--- a/stm32/ros_usbnode/include/perimeter.h
+++ b/stm32/ros_usbnode/include/perimeter.h
@@ -53,6 +53,7 @@ extern ADC_HandleTypeDef ADC_Handle;
 /******************************************************************************
 * PUBLIC Function Prototypes
 *******************************************************************************/
+void Perimeter_vInit(void);
 void Perimeter_vApp(void);
 void PERIMETER_vITHandle(void);
 


### PR DESCRIPTION
Add prototype Perimeter_vInit